### PR TITLE
Fix for various rust changes.

### DIFF
--- a/src/util/async/core.rs
+++ b/src/util/async/core.rs
@@ -66,7 +66,7 @@ impl<T: Send, E: Send> Core<T, E> {
 
     /// Registers a callback that will be invoked when calling `consumer_poll`
     /// will return a value.
-    pub fn consumer_ready<F: FnOnce(Core<T, E>) + Send>(&self, f: F) -> Option<u64> {
+    pub fn consumer_ready<F: FnOnce(Core<T, E>) + Send + 'static>(&self, f: F) -> Option<u64> {
         self.inner().consumer_ready(f)
     }
 
@@ -103,7 +103,7 @@ impl<T: Send, E: Send> Core<T, E> {
         }
     }
 
-    pub fn producer_ready<F: FnOnce(Core<T, E>) + Send>(&self, f: F) {
+    pub fn producer_ready<F: FnOnce(Core<T, E>) + Send + 'static>(&self, f: F) {
         self.inner().producer_ready(f);
     }
 
@@ -249,7 +249,7 @@ impl<T: Send, E: Send> CoreInner<T, E> {
         Some(self.consume_val(curr))
     }
 
-    fn consumer_ready<F: FnOnce(Core<T, E>) + Send>(&self, f: F) -> Option<u64> {
+    fn consumer_ready<F: FnOnce(Core<T, E>) + Send + 'static>(&self, f: F) -> Option<u64> {
         let mut curr = self.state.load(Relaxed);
 
         debug!("Core::consumer_ready; state={:?}", curr);
@@ -450,7 +450,7 @@ impl<T: Send, E: Send> CoreInner<T, E> {
         Some(Ok(self.core()))
     }
 
-    fn producer_ready<F: FnOnce(Core<T, E>) + Send>(&self, f: F) {
+    fn producer_ready<F: FnOnce(Core<T, E>) + Send + 'static>(&self, f: F) {
         let mut curr = self.state.load(Relaxed);
 
         debug!("Core::producer_ready; state={:?}", curr);

--- a/src/util/async/future.rs
+++ b/src/util/async/future.rs
@@ -139,7 +139,7 @@ impl<T: Send, E: Send> Future<T, E> {
     }
 }
 
-impl<T: Send> Future<T, ()> {
+impl<T: Send + 'static> Future<T, ()> {
     /// Returns a `Future` representing the completion of the given closure.
     /// The closure will be executed on a newly spawned thread.
     ///
@@ -153,7 +153,7 @@ impl<T: Send> Future<T, ()> {
     ///
     /// assert_eq!(100, future.await().unwrap());
     pub fn spawn<F>(f: F) -> Future<T, ()>
-        where F: FnOnce() -> T + Send {
+        where F: FnOnce() -> T + Send + 'static {
 
         use std::thread::Thread;
         let (complete, future) = Future::pair();

--- a/src/util/async/join.rs
+++ b/src/util/async/join.rs
@@ -108,9 +108,6 @@ struct ProgressInner<P: Partial<R>, R: Send, E: Send> {
     remaining: AtomicInt,
 }
 
-unsafe impl<P: Partial<R>, R: Send, E: Send> Sync for UnsafeCell<ProgressInner<P, R, E>> {
-}
-
 macro_rules! expr {
     ($e: expr) => { $e };
 }

--- a/src/util/async/receipt.rs
+++ b/src/util/async/receipt.rs
@@ -1,10 +1,11 @@
 use super::Async;
 use super::core::Core;
-use std::{mem, ptr};
+use std::{mem, ptr, marker};
 
 pub struct Receipt<A: Async> {
     core: *const (),
     count: u64,
+    _marker: marker::PhantomData<A>,
 }
 
 unsafe impl<A: Async> Send for Receipt<A> { }
@@ -13,6 +14,7 @@ pub fn new<A: Async, T: Send, E: Send>(core: Core<T, E>, count: u64) -> Receipt<
     Receipt {
         core: unsafe { mem::transmute(core) },
         count: count,
+        _marker: marker::PhantomData,
     }
 }
 
@@ -20,6 +22,7 @@ pub fn none<A: Async>() -> Receipt<A> {
     Receipt {
         core: ptr::null(),
         count: 0,
+        _marker: marker::PhantomData,
     }
 }
 

--- a/src/util/async/select.rs
+++ b/src/util/async/select.rs
@@ -63,8 +63,6 @@ struct Selection<V: Values<S, E>, S: Select<E>, E: Send> {
     core: Arc<UnsafeCell<Core<V, S, E>>>,
 }
 
-unsafe impl<V, S, E> Sync for UnsafeCell<Core<V, S, E>> { }
-
 // This implementation is very unsafe
 impl<V: Values<S, E>, S: Select<E>, E: Send> Selection<V, S, E> {
 

--- a/src/util/atomic.rs
+++ b/src/util/atomic.rs
@@ -38,6 +38,7 @@ pub trait Atomic<T> : Send + Sync {
 
 /// A value that can be stored in an atomic box
 pub trait ToAtomicRepr : Send {
+    type AtomicRepr: Atomic<Self::Repr>;
 
     /// The representation of the value when stored in an atomic box.
     type Repr;
@@ -50,21 +51,21 @@ pub trait ToAtomicRepr : Send {
 }
 
 // TODO: Move A -> ToAtomicRepr associated type (blocked rust-lang/rust#20772)
-pub struct AtomicVal<T: ToAtomicRepr, A: Atomic<T::Repr>> {
-    atomic: A,
+pub struct AtomicVal<T: ToAtomicRepr> {
+    atomic: T::AtomicRepr,
 }
 
-impl<T: ToAtomicRepr, A: Atomic<T::Repr>> AtomicVal<T, A> {
+impl<T: ToAtomicRepr> AtomicVal<T> {
     /// Returns a new atomic box
-    pub fn new(init: T) -> AtomicVal<T, A> {
-        AtomicVal { atomic: <A as Atomic<T::Repr>>::new(init.to_repr()) }
+    pub fn new(init: T) -> AtomicVal<T> {
+        AtomicVal { atomic: <T::AtomicRepr>::new(init.to_repr()) }
     }
 }
 
-impl<T: ToAtomicRepr, A: Atomic<T::Repr>> Atomic<T> for AtomicVal<T, A> {
+impl<T: ToAtomicRepr> Atomic<T> for AtomicVal<T> {
 
     /// Returns a new atomic box
-    fn new(init: T) -> AtomicVal<T, A> {
+    fn new(init: T) -> AtomicVal<T> {
         AtomicVal::new(init)
     }
 


### PR DESCRIPTION
- Send no longer implies 'static
- Associated types allow the removal of a type parameter.

Unfortunately this is causing a stack overflow in rustc :/
