### PR TITLE
Make Run object-safe by using Thunk.

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -1,4 +1,21 @@
+use std::thunk::Thunk;
+
 pub trait Run {
     /// Runs the task on the underlying executor.
-    fn run<F>(&self, task: F) where F: FnOnce() + Send;
+    ///
+    /// This uses a `Thunk` rather than a generic `FnOnce` so that
+    /// `Run` is object safe.
+    fn run(&self, task: Thunk<'static>);
 }
+
+#[test]
+fn test_run_is_object_safe() {
+    struct X;
+
+    impl Run for X {
+        fn run(&self, _: Thunk) {}
+    }
+
+    let _x: &Run = &X;
+}
+

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -4,6 +4,7 @@ use super::run::Run;
 use std::num::FromPrimitive;
 use std::sync::{Arc, Mutex, Condvar};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thunk::Thunk;
 use std::thread;
 
 use self::Lifecycle::*;
@@ -57,8 +58,8 @@ impl ThreadPool {
 }
 
 impl Run for ThreadPool {
-    fn run<F>(&self, task: F) where F: FnOnce() + Send + 'static {
-        ThreadPool::run(self, task);
+    fn run(&self, task: Thunk<'static>) {
+        ThreadPool::run(self, move || { task.invoke(()) })
     }
 }
 


### PR DESCRIPTION
It is quite useful to have `Run` trait objects, and this comes
at only a very minor performance hit in most cases. It certainly
will generate less code.
