### PR TITLE
fix rfc 1214 fallout

### DIFF
--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -6,10 +6,10 @@ use std::{thread, usize};
 use time::Duration;
 
 /// A queue that can be used to back a thread pool
-pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
+pub trait WorkQueue<T: Send> : SyncQueue<Option<T>> + Clone + Send + 'static {
 }
 
-impl<T, Q: SyncQueue<Option<T>> + Clone + Send + 'static> WorkQueue<T> for Q {
+impl<T: Send, Q: SyncQueue<Option<T>> + Clone + Send + 'static> WorkQueue<T> for Q {
 }
 
 pub struct ThreadPool<T: Task+'static, Q: WorkQueue<T> = LinkedQueue<Option<T>>> {

--- a/test/test_thread_pool.rs
+++ b/test/test_thread_pool.rs
@@ -68,7 +68,7 @@ pub fn test_two_threads_task_queue_up() {
 
 #[test]
 pub fn test_thread_pool_is_send() {
-    fn check<R: Run<F> + Send, F: FnOnce() + Send>(_: &R) {
+    fn check<R: Run<F> + Send, F: FnOnce() + Send + 'static>(_: &R) {
     }
 
     let tp = ThreadPool::fixed_size(2);


### PR DESCRIPTION
[RFC 1214](https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md) fixed some bugs / incorrect behaviour in `rustc` which requires additional bounds in some places.

The errors were:

``` plain
src/thread_pool.rs:9:1: 10:2 warning: the trait `core::marker::Send` is not implemented for the type `T` [E0277]
src/thread_pool.rs: 9 pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
src/thread_pool.rs:10 }
src/thread_pool.rs:9:1: 10:2 help: run `rustc --explain E0277` to see a detailed explanation
src/thread_pool.rs:9:1: 10:2 note: `T` cannot be sent between threads safely
src/thread_pool.rs: 9 pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
src/thread_pool.rs:10 }
src/thread_pool.rs:9:1: 10:2 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/thread_pool.rs: 9 pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
src/thread_pool.rs:10 }
src/thread_pool.rs:9:1: 10:2 note: required because it appears within the type `core::option::Option<T>`
src/thread_pool.rs: 9 pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
src/thread_pool.rs:10 }
src/thread_pool.rs:9:1: 10:2 note: required by `queue::SyncQueue`
src/thread_pool.rs: 9 pub trait WorkQueue<T> : SyncQueue<Option<T>> + Clone + Send + 'static {
src/thread_pool.rs:10 }

test/test_thread_pool.rs:71:5: 72:6 warning: the parameter type `F` may not live long enough [E0310]
test/test_thread_pool.rs:71     fn check<R: Run<F> + Send, F: FnOnce() + Send>(_: &R) {
test/test_thread_pool.rs:72     }
test/test_thread_pool.rs:71:5: 72:6 help: run `rustc --explain E0310` to see a detailed explanation
test/test_thread_pool.rs:71:5: 72:6 help: consider adding an explicit lifetime bound `F: 'static`...
test/test_thread_pool.rs:71:5: 72:6 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
test/test_thread_pool.rs:71     fn check<R: Run<F> + Send, F: FnOnce() + Send>(_: &R) {
test/test_thread_pool.rs:72     }
test/test_thread_pool.rs:71:5: 72:6 note: ...so that the type `F` will meet its required lifetime bounds
test/test_thread_pool.rs:71     fn check<R: Run<F> + Send, F: FnOnce() + Send>(_: &R) {
test/test_thread_pool.rs:72     }
```
