### PR TITLE
Use notify_one instead of notify_all in DelayQueue

### DIFF
--- a/src/delay_queue.rs
+++ b/src/delay_queue.rs
@@ -104,7 +104,7 @@ impl<T: Delayed + Send> DelayQueue<T> {
 
     fn finish_pop<'a>(&self, mut queue: MutexGuard<'a, BinaryHeap<Entry<T>>>) -> T {
         if queue.len() > 1 {
-            self.inner.condvar.notify_all();
+            self.inner.condvar.notify_one();
         }
 
         queue.pop().unwrap().val
@@ -139,10 +139,10 @@ impl<T: Delayed + Send> Queue<T> for DelayQueue<T> {
         match queue.peek() {
             Some(e) => {
                 if entry.time < e.time {
-                    self.inner.condvar.notify_all()
+                    self.inner.condvar.notify_one()
                 }
             }
-            None => self.inner.condvar.notify_all(),
+            None => self.inner.condvar.notify_one(),
         }
 
         queue.push(entry);


### PR DESCRIPTION
Since any thread can pick up the newly available item, we only need to
wake up one of them.
